### PR TITLE
Not tested for ms2/ms1, but works fine with FreeEMS and solves all the mac issues.

### DIFF
--- a/msloader/loader_common.c
+++ b/msloader/loader_common.c
@@ -123,7 +123,7 @@ gint setup_port(gint fd, gint baud)
 	newtio.c_cc[VKILL]    = 0;     /* @ */
 	newtio.c_cc[VEOF]     = 0;     /* Ctrl-d */
 	newtio.c_cc[VEOL]     = 0;     /* '\0' */
-	newtio.c_cc[VMIN]     = 0;     /* No min chars requirement */
+	newtio.c_cc[VMIN]     = 1;     /* No min chars requirement */
 	newtio.c_cc[VTIME]    = 1;     /* 100ms timeout */
 
 	tcsetattr(fd,TCSANOW,&newtio);

--- a/src/serialio.c
+++ b/src/serialio.c
@@ -335,7 +335,7 @@ G_MODULE_EXPORT void setup_serial_params(void)
 	serial_params->newtio.c_cc[VEOF]     = 0;     /* Ctrl-d */
 	serial_params->newtio.c_cc[VEOL]     = 0;     /* '\0' */
 	serial_params->newtio.c_cc[VTIME]    = 1;     /* 100ms timeout */
-	serial_params->newtio.c_cc[VMIN]     = 0;     
+	serial_params->newtio.c_cc[VMIN]     = 1;     
 
 #ifdef __PIS_SUPPORT__
 	if (ioctl(serial_params->fd, TIOCGSERIAL, &serial_params->oldctl) != 0)


### PR DESCRIPTION
Fix bugs on osx with ftdi adapter. Driver has a bug in it that causes the input devices (also on usb) to hang when closing the apps. This change causes mtx and friends to not stimulate that condition, thereby producing a smooth reliable experience for osx users.
